### PR TITLE
Add Energy Subscription module

### DIFF
--- a/addons/energy_subscription/__init__.py
+++ b/addons/energy_subscription/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/addons/energy_subscription/__manifest__.py
+++ b/addons/energy_subscription/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'Energy Subscription',
+    'version': '0.1',
+    'summary': 'Manage customer energy subscriptions',
+    'description': """Manage energy credits for customers with periodic billing.
+Customers purchase kWh that can be manually or automatically refilled.
+Credit and debit operations are available through the standard API.""",
+    'author': 'My Company',
+    'category': 'Services',
+    'depends': ['base'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/energy_subscription_menu.xml',
+        'views/energy_subscription_views.xml',
+        'views/energy_subscription_wizard.xml',
+        'report/bill_report.xml',
+        'data/cron.xml',
+    ],
+    'installable': True,
+    'application': True,
+}

--- a/addons/energy_subscription/data/cron.xml
+++ b/addons/energy_subscription/data/cron.xml
@@ -1,0 +1,11 @@
+<odoo>
+    <record id="ir_cron_energy_generate_bills" model="ir.cron">
+        <field name="name">Generate Energy Bills</field>
+        <field name="model_id" ref="model_energy_subscription"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_generate_bills()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">months</field>
+        <field name="numbercall">-1</field>
+    </record>
+</odoo>

--- a/addons/energy_subscription/models/__init__.py
+++ b/addons/energy_subscription/models/__init__.py
@@ -1,0 +1,4 @@
+from . import subscription
+from . import bill
+from . import rfid_card
+from . import vin

--- a/addons/energy_subscription/models/bill.py
+++ b/addons/energy_subscription/models/bill.py
@@ -1,0 +1,11 @@
+from odoo import models, fields
+
+
+class EnergyBill(models.Model):
+    _name = 'energy.bill'
+    _description = 'Energy Bill'
+
+    subscription_id = fields.Many2one('energy.subscription', required=True, ondelete='cascade')
+    partner_id = fields.Many2one(related='subscription_id.partner_id', store=True)
+    date = fields.Date(default=fields.Date.context_today)
+    amount_kwh = fields.Float(string='kWh Amount')

--- a/addons/energy_subscription/models/rfid_card.py
+++ b/addons/energy_subscription/models/rfid_card.py
@@ -1,0 +1,26 @@
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError
+import re
+
+
+class EnergySubscriptionRFID(models.Model):
+    _name = 'energy.subscription.rfid'
+    _description = 'Energy Subscription RFID Card'
+
+    subscription_id = fields.Many2one('energy.subscription', required=True, ondelete='cascade')
+    rfid_number = fields.Char(required=True, string='RFID Card Number')
+
+    _sql_constraints = [
+        (
+            'rfid_number_hex',
+            "CHECK (rfid_number ~ '^[0-9A-Fa-f]{8}$')",
+            'RFID number must be exactly 8 hexadecimal digits.',
+        ),
+    ]
+
+    @api.constrains('rfid_number')
+    def _check_rfid_number(self):
+        hex_re = re.compile(r'^[0-9A-Fa-f]{8}$')
+        for rec in self:
+            if not hex_re.match(rec.rfid_number or ''):
+                raise ValidationError('RFID number must be 8 hex digits (e.g. FFFFFFFF)')

--- a/addons/energy_subscription/models/subscription.py
+++ b/addons/energy_subscription/models/subscription.py
@@ -1,0 +1,42 @@
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
+
+
+class EnergySubscription(models.Model):
+    _name = 'energy.subscription'
+    _description = 'Energy Subscription'
+
+    name = fields.Char(required=True)
+    partner_id = fields.Many2one('res.partner', string='Customer', required=True)
+    kwh_balance = fields.Float(string='kWh Balance', default=0.0)
+    period_months = fields.Integer(string='Review Period (months)', default=1)
+    next_review_date = fields.Date(string='Next Review Date')
+    rfid_ids = fields.One2many('energy.subscription.rfid', 'subscription_id', string='RFID Cards')
+    vin_ids = fields.One2many('energy.subscription.vin', 'subscription_id', string='VINs')
+    allow_overcharge = fields.Boolean(string='Allow Overcharge', default=False)
+
+    def credit_kwh(self, amount):
+        for sub in self:
+            sub.kwh_balance += amount
+        return True
+
+    def debit_kwh(self, amount):
+        for sub in self:
+            new_balance = sub.kwh_balance - amount
+            if new_balance < 0 and not sub.allow_overcharge:
+                raise ValidationError(
+                    _('Subscription %s cannot be overcharged') % sub.display_name
+                )
+            sub.kwh_balance = new_balance
+        return True
+
+    @api.model
+    def _cron_generate_bills(self):
+        today = fields.Date.context_today(self)
+        subs = self.search([('next_review_date', '<=', today)])
+        for sub in subs:
+            self.env['energy.bill'].create({
+                'subscription_id': sub.id,
+                'amount_kwh': sub.kwh_balance,
+            })
+            sub.next_review_date = fields.Date.add(today, months=sub.period_months)

--- a/addons/energy_subscription/models/vin.py
+++ b/addons/energy_subscription/models/vin.py
@@ -1,0 +1,9 @@
+from odoo import models, fields
+
+
+class EnergySubscriptionVIN(models.Model):
+    _name = 'energy.subscription.vin'
+    _description = 'Energy Subscription VIN'
+
+    subscription_id = fields.Many2one('energy.subscription', required=True, ondelete='cascade')
+    vin = fields.Char(required=True, string='Vehicle VIN')

--- a/addons/energy_subscription/report/bill_report.xml
+++ b/addons/energy_subscription/report/bill_report.xml
@@ -1,0 +1,19 @@
+<odoo>
+    <record id="energy_bill_report" model="ir.actions.report">
+        <field name="name">Energy Bill</field>
+        <field name="model">energy.bill</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">energy_subscription.report_energy_bill</field>
+    </record>
+
+    <template id="report_energy_bill">
+        <t t-call="web.basic_layout">
+            <div class="page">
+                <h2>Energy Bill</h2>
+                <p>Customer: <t t-esc="doc.partner_id.name"/></p>
+                <p>Date: <t t-esc="doc.date"/></p>
+                <p>Amount (kWh): <t t-esc="doc.amount_kwh"/></p>
+            </div>
+        </t>
+    </template>
+</odoo>

--- a/addons/energy_subscription/security/ir.model.access.csv
+++ b/addons/energy_subscription/security/ir.model.access.csv
@@ -1,0 +1,6 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_energy_subscription_user,energy.subscription,model_energy_subscription,base.group_user,1,1,1,1
+access_energy_bill_user,energy.bill,model_energy_bill,base.group_user,1,1,1,1
+access_energy_subscription_rfid_user,energy.subscription.rfid,model_energy_subscription_rfid,base.group_user,1,1,1,1
+access_energy_subscription_vin_user,energy.subscription.vin,model_energy_subscription_vin,base.group_user,1,1,1,1
+access_energy_subscription_adjust_wizard,energy.subscription.adjust.wizard,model_energy_subscription_adjust_wizard,base.group_user,1,1,1,1

--- a/addons/energy_subscription/views/energy_subscription_menu.xml
+++ b/addons/energy_subscription/views/energy_subscription_menu.xml
@@ -1,0 +1,5 @@
+<odoo>
+    <menuitem id="energy_subscription_menu_root" name="Energy"/>
+    <menuitem id="energy_subscription_menu" name="Subscriptions" parent="energy_subscription_menu_root" action="energy_subscription_action"/>
+    <menuitem id="energy_bill_menu" name="Bills" parent="energy_subscription_menu_root" action="energy_bill_action"/>
+</odoo>

--- a/addons/energy_subscription/views/energy_subscription_views.xml
+++ b/addons/energy_subscription/views/energy_subscription_views.xml
@@ -1,0 +1,104 @@
+<odoo>
+    <record id="energy_subscription_action" model="ir.actions.act_window">
+        <field name="name">Energy Subscriptions</field>
+        <field name="res_model">energy.subscription</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record id="energy_bill_action" model="ir.actions.act_window">
+        <field name="name">Energy Bills</field>
+        <field name="res_model">energy.bill</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record id="view_energy_subscription_tree" model="ir.ui.view">
+        <field name="name">energy.subscription.tree</field>
+        <field name="model">energy.subscription</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="kwh_balance"/>
+                <field name="period_months"/>
+                <field name="next_review_date"/>
+                <field name="allow_overcharge"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_energy_subscription_form" model="ir.ui.view">
+        <field name="name">energy.subscription.form</field>
+        <field name="model">energy.subscription</field>
+        <field name="arch" type="xml">
+            <form string="Energy Subscription">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="partner_id"/>
+                        <field name="kwh_balance"/>
+                        <field name="period_months"/>
+                        <field name="next_review_date"/>
+                        <field name="allow_overcharge"/>
+                        <field name="rfid_ids">
+                            <tree editable="bottom">
+                                <field name="rfid_number"/>
+                            </tree>
+                        </field>
+                        <field name="vin_ids">
+                            <tree editable="bottom">
+                                <field name="vin"/>
+                            </tree>
+                        </field>
+                    </group>
+                    <footer>
+                        <button
+                            name="%(action_energy_subscription_credit)d"
+                            string="Credit"
+                            type="action"
+                            context="{'default_subscription_id': active_id}"
+                        />
+                        <button
+                            name="%(action_energy_subscription_debit)d"
+                            string="Debit"
+                            type="action"
+                            context="{'default_subscription_id': active_id}"
+                        />
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_energy_bill_tree" model="ir.ui.view">
+        <field name="name">energy.bill.tree</field>
+        <field name="model">energy.bill</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="subscription_id"/>
+                <field name="partner_id"/>
+                <field name="date"/>
+                <field name="amount_kwh"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_energy_bill_form" model="ir.ui.view">
+        <field name="name">energy.bill.form</field>
+        <field name="model">energy.bill</field>
+        <field name="arch" type="xml">
+            <form string="Energy Bill">
+                <sheet>
+                    <group>
+                        <field name="subscription_id"/>
+                        <field name="partner_id"/>
+                        <field name="date"/>
+                        <field name="amount_kwh"/>
+                    </group>
+                    <footer>
+                        <button string="Print" type="action" name="%(energy_bill_report)d" class="btn-primary"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/energy_subscription/views/energy_subscription_wizard.xml
+++ b/addons/energy_subscription/views/energy_subscription_wizard.xml
@@ -1,0 +1,35 @@
+<odoo>
+    <record id="view_energy_subscription_adjust_wizard" model="ir.ui.view">
+        <field name="name">energy.subscription.adjust.wizard.form</field>
+        <field name="model">energy.subscription.adjust.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Adjust Balance">
+                <group>
+                    <field name="subscription_id" readonly="1"/>
+                    <field name="operation"/>
+                    <field name="amount"/>
+                </group>
+                <footer>
+                    <button string="Apply" type="object" name="action_apply" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_energy_subscription_credit" model="ir.actions.act_window">
+        <field name="name">Credit Subscription</field>
+        <field name="res_model">energy.subscription.adjust.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{'default_operation': 'credit'}</field>
+    </record>
+
+    <record id="action_energy_subscription_debit" model="ir.actions.act_window">
+        <field name="name">Debit Subscription</field>
+        <field name="res_model">energy.subscription.adjust.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="context">{'default_operation': 'debit'}</field>
+    </record>
+</odoo>

--- a/addons/energy_subscription/wizards/__init__.py
+++ b/addons/energy_subscription/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import adjust_wizard

--- a/addons/energy_subscription/wizards/adjust_wizard.py
+++ b/addons/energy_subscription/wizards/adjust_wizard.py
@@ -1,0 +1,21 @@
+from odoo import models, fields
+
+
+class EnergySubscriptionAdjustWizard(models.TransientModel):
+    _name = 'energy.subscription.adjust.wizard'
+    _description = 'Adjust Energy Subscription Balance'
+
+    subscription_id = fields.Many2one('energy.subscription', required=True)
+    amount = fields.Float(required=True)
+    operation = fields.Selection([
+        ('credit', 'Credit'),
+        ('debit', 'Debit'),
+    ], required=True, default='credit')
+
+    def action_apply(self):
+        self.ensure_one()
+        if self.operation == 'credit':
+            self.subscription_id.credit_kwh(self.amount)
+        else:
+            self.subscription_id.debit_kwh(self.amount)
+        return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
## Summary
- scaffold new `energy_subscription` module
- add subscription & bill models with credit/debit helpers
- create menus, views and periodic bill cron
- provide a simple PDF report template
- allow multiple card numbers per subscription
- add wizard to manually adjust subscription balance
- rename card model to RFID and validate 8-digit hex
- track vehicle VIN numbers per subscription
- add field to allow overcharge on subscriptions

## Testing
- `python3 -m py_compile addons/energy_subscription/**/*.py`
- `python3 -m pip install -r requirements.txt` *(fails to build python-ldap)*

------
https://chatgpt.com/codex/tasks/task_e_686d7934b08483268b7b72e2de2948eb